### PR TITLE
Add puppeteerLaunchOptions to renderEjsToImageBuffer

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ Convert EJS templates into PNG or JPEG images using Puppeteer. Perfect for gener
 - 🚀 Built with Puppeteer for high-quality rendering
 
 ## Installation
+
 [![NPM](https://nodei.co/npm/ejs2img.png)](https://www.npmjs.com/package/ejs2img)
 
 ```bash
@@ -65,6 +66,7 @@ Render an EJS template to image buffer.
 - `transparent` (boolean): Transparent background, PNG only (default: false)
 - `format` (string): Output format "png" or "jpeg" (default: "png")
 - `quality` (number): JPEG quality 0-100 (default: 80)
+- `puppeteerLaunchOptions` (object): Options forwarded to puppeteer.launch() (e.g. executablePath, args, etc. https://pptr.dev/api/puppeteer.launchoptions)
 
 **Returns:** `Promise<Buffer>` - Image buffer
 
@@ -115,6 +117,11 @@ const buffer = await renderEjsToImageBuffer(
     height: 1080,
     format: "jpeg",
     quality: 95,
+    puppeteerLaunchOptions: {
+      executablePath: "/usr/bin/chromium-browser",
+      // all launch options
+      // https://pptr.dev/api/puppeteer.launchoptions
+    },
   }
 );
 ```

--- a/index.d.ts
+++ b/index.d.ts
@@ -11,6 +11,8 @@ export interface RenderOptions {
   format?: "png" | "jpeg";
   /** JPEG quality 0–100 (only applies to JPEG) */
   quality?: number;
+  /** Options passed directly to puppeteer.launch */
+  puppeteerLaunchOptions?: import("puppeteer").PuppeteerLaunchOptions;
 }
 
 /**

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ejs2img",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "Render EJS templates into PNG or JPEG images using Puppeteer",
   "type": "module",
   "main": "src/index.js",

--- a/src/index.js
+++ b/src/index.js
@@ -26,6 +26,7 @@ export async function renderEjsToHtml(ejsPath, data = {}) {
  * @param {boolean} [options.transparent=false] Transparent background (PNG only).
  * @param {"png"|"jpeg"} [options.format="png"] Image format.
  * @param {number} [options.quality] JPEG quality (0–100).
+ * @param {object} [options.puppeteerLaunchOptions] Options passed directly to puppeteer.launch.
  * @returns {Promise<Buffer>} Image buffer.
  */
 export async function renderEjsToImageBuffer(ejsPath, data = {}, options = {}) {
@@ -35,13 +36,15 @@ export async function renderEjsToImageBuffer(ejsPath, data = {}, options = {}) {
         fullPage = false,
         transparent = false,
         format = "png",
-        quality
+        quality,
+        puppeteerLaunchOptions = {}
     } = options;
 
     const html = await renderEjsToHtml(ejsPath, data);
 
     const browser = await puppeteer.launch({
-        args: ["--no-sandbox", "--disable-setuid-sandbox"]
+        args: ["--no-sandbox", "--disable-setuid-sandbox"],
+        ...puppeteerLaunchOptions
     });
 
     try {


### PR DESCRIPTION
Introduces a new 'puppeteerLaunchOptions' option to renderEjsToImageBuffer, allowing users to pass custom options directly to puppeteer.launch. Updates documentation and type definitions to reflect this enhancement.